### PR TITLE
Fixed CCPE URL + added missing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ tqdm
 torch
 nltk
 transformers==3.3.1
+librosa
+pysptk

--- a/ttd/datasets/coached.py
+++ b/ttd/datasets/coached.py
@@ -32,8 +32,8 @@ random.seed(10)  # for split creation
 
 
 class CoachedBuilder(BaseBuilder):
-    URL = "https://storage.googleapis.com/dialog-data-corpus/CCPE-M-2019/data.json"
-    README = "https://storage.googleapis.com/dialog-data-corpus/CCPE-M-2019/README.txt"
+    URL = "https://raw.githubusercontent.com/google-research-datasets/ccpe/main/data.json"
+    README = "https://raw.githubusercontent.com/google-research-datasets/ccpe/main/README.md"
     NAME = "Coached"
     SPLIT = {"train": 0.9, "test": 0.05}  # validation is remaining
 


### PR DESCRIPTION
Hi,

The upstream URL for the coached CCPE datasaet returned a 404. I looked it up online and found it on GitHub here: https://github.com/google-research-datasets/ccpe.
I replaced the URL and README (though the latter one isn't as useful) to fetch them correctly.

Furthermore, `ttd/pitch.py` requires both `librosa` and `pysptk`, both of them were missing in the `requirements.txt` file. I added them both as well.

I hope it will be any useful to you!